### PR TITLE
feat: Health checks for tokens

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -3,3 +3,15 @@ package main
 type BidStruct struct {
 	Amount int `json:"amount"`
 }
+
+type TokenHealtCheck struct {
+	State       string                `json:"state"`
+	UserResults []TokenHealtCheckUser `json:"userResults"`
+}
+type TokenHealtCheckUser struct {
+	State             string `json:"state"`
+	User              string `json:"user"`
+	UserTokens        int    `json:"userTokens"`
+	TransactionTokens int    `json:"transactionTokens"`
+	Differece         int    `json:"differece"`
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,11 @@ func main() {
 			app.Logger().Error("updateUserNames error", "error", err)
 		}
 	})
+	app.Cron().MustAdd("runTokenHealthCheck", "0 1 * * *", func() {
+		if err := runTokenHealthCheck(app); err != nil {
+			app.Logger().Error("runTokenHealthCheck error", "error", err)
+		}
+	})
 	// loosely check if it was executed using "go run"
 	isGoRun := strings.HasPrefix(os.Args[0], os.TempDir())
 

--- a/migrations/1737898963_created_tokenHealthChecks.go
+++ b/migrations/1737898963_created_tokenHealthChecks.go
@@ -1,0 +1,89 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		jsonData := `{
+			"createRule": null,
+			"deleteRule": null,
+			"fields": [
+				{
+					"autogeneratePattern": "[a-z0-9]{15}",
+					"hidden": false,
+					"id": "text3208210256",
+					"max": 15,
+					"min": 15,
+					"name": "id",
+					"pattern": "^[a-z0-9]+$",
+					"presentable": false,
+					"primaryKey": true,
+					"required": true,
+					"system": true,
+					"type": "text"
+				},
+				{
+					"hidden": false,
+					"id": "select2744374011",
+					"maxSelect": 1,
+					"name": "state",
+					"presentable": false,
+					"required": true,
+					"system": false,
+					"type": "select",
+					"values": [
+						"ok",
+						"error"
+					]
+				},
+				{
+					"hidden": false,
+					"id": "json325763347",
+					"maxSize": 0,
+					"name": "result",
+					"presentable": false,
+					"required": true,
+					"system": false,
+					"type": "json"
+				},
+				{
+					"hidden": false,
+					"id": "autodate2990389176",
+					"name": "created",
+					"onCreate": true,
+					"onUpdate": false,
+					"presentable": false,
+					"system": false,
+					"type": "autodate"
+				}
+			],
+			"id": "pbc_3198869908",
+			"indexes": [],
+			"listRule": null,
+			"name": "tokenHealthChecks",
+			"system": false,
+			"type": "base",
+			"updateRule": null,
+			"viewRule": null
+		}`
+
+		collection := &core.Collection{}
+		if err := json.Unmarshal([]byte(jsonData), &collection); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_3198869908")
+		if err != nil {
+			return err
+		}
+
+		return app.Delete(collection)
+	})
+}


### PR DESCRIPTION
Implement health checks for tokens by introducing a new structure to track user token states and differences between user tokens and transaction tokens. Schedule a cron job to run these health checks and store the results in a new collection.

Fixes #4