### PR TITLE
Change binding mechanism to release tokens on losing in auction

### DIFF
--- a/cronJobs.go
+++ b/cronJobs.go
@@ -24,13 +24,6 @@ func finishAuction(app *pocketbase.PocketBase) error {
 	}
 	return app.RunInTransaction(func(tx core.App) error {
 		for _, record := range records {
-
-			bidRecords, err := tx.FindRecordsByFilter("bids", "auction = {:auctionId}", "", 0, 0, dbx.Params{"auctionId": record.Id})
-			if err != nil {
-				return err
-			}
-			bidExists := len(bidRecords) > 0
-
 			record.Set("state", "finished")
 
 			coll, err := tx.FindCachedCollectionByNameOrId("auctionsResult")
@@ -39,36 +32,25 @@ func finishAuction(app *pocketbase.PocketBase) error {
 			}
 			resultRecord := core.NewRecord(coll)
 			resultRecord.Set("auction", record.Id)
-			if bidExists {
-				winnerRecordIndex := -1
-				for i := range bidRecords {
-					if winnerRecordIndex < 0 || bidRecords[i].GetInt("amount") > bidRecords[winnerRecordIndex].GetInt("amount") {
-						winnerRecordIndex = i
-					}
-				}
-				record.Set("winner", bidRecords[winnerRecordIndex].GetString("user"))
-				for _, bidRecord := range bidRecords {
-					userRecord, err := tx.FindRecordById("users", bidRecord.GetString("user"))
-					if err != nil {
-						return err
-					}
 
-					if bidRecord.Id == bidRecords[winnerRecordIndex].Id {
-						userRecord.Set("reservedTokens", userRecord.GetInt("reservedTokens")-bidRecord.GetInt("amount"))
-						userRecord.Set("tokens", userRecord.GetInt("tokens")-bidRecord.GetInt("amount"))
-						if err := createTransactionRecord(tx, userRecord.Id, -bidRecord.GetInt("amount"), "Win in auction", ""); err != nil {
-							return err
-						}
-						notifyUser(userRecord.Id, "You won the auction")
-					} else {
-						userRecord.Set("reservedTokens", userRecord.GetInt("reservedTokens")-bidRecord.GetInt("amount"))
-					}
-					err = tx.Save(userRecord)
-					if err != nil {
-						return err
-					}
+			if record.GetString("winner") != "" {
+
+				userRecord, err := tx.FindRecordById("users", record.GetString("winner"))
+				if err != nil {
+					return err
 				}
+
+				userRecord.Set("reservedTokens", userRecord.GetInt("reservedTokens")-record.GetInt("currentBid"))
+				userRecord.Set("tokens", userRecord.GetInt("tokens")-record.GetInt("currentBid"))
+				if err := createTransactionRecord(tx, userRecord.Id, -record.GetInt("currentBid"), "Win in auction", ""); err != nil {
+					return err
+				}
+				if err := tx.Save(userRecord); err != nil {
+					return err
+				}
+				notifyUser(userRecord.Id, "You won the auction")
 			}
+
 			err = tx.Save(record)
 			if err != nil {
 				return err
@@ -76,6 +58,7 @@ func finishAuction(app *pocketbase.PocketBase) error {
 			if err := tx.Save(resultRecord); err != nil {
 				return err
 			}
+
 			notifyRole("manager", "Auction has ended")
 		}
 		return nil


### PR DESCRIPTION
The update modifies the auction winner handling to release tokens from the previous winner when a new bid is placed, rather than only at the end of the auction. This change ensures that tokens are managed more effectively throughout the auction process. Fixes #15