### PR TITLE
Add TLDB adapter sync settings and migration for new fields

### DIFF
--- a/contracts.go
+++ b/contracts.go
@@ -30,6 +30,8 @@ type Settings struct {
 	SynchronizationDiscordGuildId string `db:"synchronizationDiscordGuildId"`
 	EnableFloatingEndOfAuction    bool   `db:"enableFloatingEndOfAuction"`
 	FloatingEndOfAuctionMinutes   int    `db:"floatingEndOfAuctionMinutes"`
+	EnableTLDBAdapterSync         bool   `db:"enableTLDBAdapterSync"`
+	TldbAdapterUrl                string `db:"tldbAdapterUrl"`
 }
 
 type TLDBAdapterResponse struct {

--- a/cronJobs.go
+++ b/cronJobs.go
@@ -227,13 +227,21 @@ func runTokenHealthCheck(app *pocketbase.PocketBase) error {
 }
 
 func getTLDBItems(app *pocketbase.PocketBase) error {
-	/*settings, err := GetSettings(app)
+	settings, err := GetSettings(app)
 	if err != nil {
 		return err
-	}*/
+	}
+	if !settings.EnableTLDBAdapterSync {
+		app.Logger().Info("TLDB Adapter Sync is disabled in settings")
+		return nil
+	}
 	httpClient := &http.Client{}
 
-	req, err := http.NewRequest("GET", "http://cc4osss0s044wssggks84ws8.37.205.12.23.sslip.io/api/data", nil)
+	url, err := url.JoinPath(settings.TldbAdapterUrl, "/api/data")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
 	}

--- a/migrations/1748106364_updated_settings.go
+++ b/migrations/1748106364_updated_settings.go
@@ -1,0 +1,61 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_2769025244")
+		if err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(9, []byte(`{
+			"hidden": false,
+			"id": "bool3933227055",
+			"name": "enableTLDBAdapterSync",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(10, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "text640587563",
+			"max": 0,
+			"min": 0,
+			"name": "tldbAdapterUrl",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_2769025244")
+		if err != nil {
+			return err
+		}
+
+		// remove field
+		collection.Fields.RemoveById("bool3933227055")
+
+		// remove field
+		collection.Fields.RemoveById("text640587563")
+
+		return app.Save(collection)
+	})
+}

--- a/util.go
+++ b/util.go
@@ -44,6 +44,8 @@ func GetSettings(app core.App) (*Settings, error) {
 				SynchronizationDiscordGuildId: "",
 				EnableFloatingEndOfAuction:    false,
 				FloatingEndOfAuctionMinutes:   0,
+				EnableTLDBAdapterSync:         false,
+				TldbAdapterUrl:                "",
 			}
 			if _, err := app.DB().Insert("settings", dbx.Params{}).Execute(); err != nil {
 				return nil, err


### PR DESCRIPTION
Introduce new settings for TLDB adapter synchronization, including a migration to add the necessary fields to the database. Update the logic to check these settings before executing TLDB-related operations.

Fixes #32