### PR TITLE
Add migration for updating collection rules in TLDB

### DIFF
--- a/migrations/1748463122_updated_items.go
+++ b/migrations/1748463122_updated_items.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_710432678")
+		if err != nil {
+			return err
+		}
+
+		// update collection data
+		if err := json.Unmarshal([]byte(`{
+			"listRule": "@request.auth.role:each ?= \"manager\"",
+			"viewRule": "@request.auth.role:each ?= \"manager\""
+		}`), &collection); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_710432678")
+		if err != nil {
+			return err
+		}
+
+		// update collection data
+		if err := json.Unmarshal([]byte(`{
+			"listRule": null,
+			"viewRule": null
+		}`), &collection); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	})
+}


### PR DESCRIPTION
Implement a migration to update the permissions for the items table, specifically setting the list and view rules to require the "manager" role. This change addresses issue #34 by ensuring proper access control for the collection.

Fixes #34