### PR TITLE
Skip saving extracts during TLDB sync

### DIFF
--- a/cronJobs.go
+++ b/cronJobs.go
@@ -269,6 +269,9 @@ func getTLDBItems(app *pocketbase.PocketBase) error {
 		return err
 	}
 	for _, item := range response.Items {
+		if strings.HasPrefix(item.Name, "Extract:") {
+			continue // Skip items that are extracts
+		}
 		formatedId := strings.ReplaceAll(item.Id, "_", "")
 
 		record, err := app.FindRecordById("items", formatedId)


### PR DESCRIPTION
Items with names starting with "Extract:" are now skipped during the TLDB synchronization process, preventing them from being saved.

Fixes #38