### PR TITLE
Fix user deletion logic to retain associated transactions

### DIFF
--- a/migrations/1758818204_updated_transactions.go
+++ b/migrations/1758818204_updated_transactions.go
@@ -1,0 +1,58 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_3174063690")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(4, []byte(`{
+			"cascadeDelete": false,
+			"collectionId": "_pb_users_auth_",
+			"hidden": false,
+			"id": "relation3182418120",
+			"maxSelect": 1,
+			"minSelect": 0,
+			"name": "author",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "relation"
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_3174063690")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(4, []byte(`{
+			"cascadeDelete": true,
+			"collectionId": "_pb_users_auth_",
+			"hidden": false,
+			"id": "relation3182418120",
+			"maxSelect": 1,
+			"minSelect": 0,
+			"name": "author",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "relation"
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	})
+}


### PR DESCRIPTION
Update the user deletion process to prevent the removal of transactions where the user is linked as an author. This change modifies the cascade delete behavior in the database migration to ensure that related transactions remain intact when a user is deleted.

Fixes #42