### PR TITLE
feat: API endpoint for adding tokens from bot

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
 	"github.com/pocketbase/pocketbase/tools/filesystem"
+	"github.com/pocketbase/pocketbase/tools/security"
 	"github.com/pocketbase/pocketbase/tools/subscriptions"
 	"golang.org/x/sync/errgroup"
 )
@@ -62,6 +63,7 @@ func main() {
 			return e.Next()
 		})
 		RegisterRoutes(se)
+		RegisterApiRoutes(se)
 		return se.Next()
 	})
 	app.OnRecordAuthWithOAuth2Request("users").BindFunc(func(e *core.RecordAuthWithOAuth2RequestEvent) error {
@@ -73,6 +75,10 @@ func main() {
 		if e.Record.GetString("role") == "" {
 			e.Record.Set("role", "member")
 		}
+		return e.Next()
+	})
+	app.OnRecordCreate("apiKeys").BindFunc(func(e *core.RecordEvent) error {
+		e.Record.Set("apiKey", security.RandomString(250))
 		return e.Next()
 	})
 	app.OnRecordAfterUpdateSuccess("users").BindFunc(func(e *core.RecordEvent) error {

--- a/migrations/1760566050_created_apiKeys.go
+++ b/migrations/1760566050_created_apiKeys.go
@@ -1,0 +1,81 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		jsonData := `{
+			"createRule": null,
+			"deleteRule": null,
+			"fields": [
+				{
+					"autogeneratePattern": "[a-z0-9]{15}",
+					"hidden": false,
+					"id": "text3208210256",
+					"max": 15,
+					"min": 15,
+					"name": "id",
+					"pattern": "^[a-z0-9]+$",
+					"presentable": false,
+					"primaryKey": true,
+					"required": true,
+					"system": true,
+					"type": "text"
+				},
+				{
+					"autogeneratePattern": "",
+					"hidden": false,
+					"id": "text2148143425",
+					"max": 0,
+					"min": 0,
+					"name": "apiKey",
+					"pattern": "",
+					"presentable": false,
+					"primaryKey": false,
+					"required": false,
+					"system": false,
+					"type": "text"
+				},
+				{
+					"hidden": false,
+					"id": "autodate2990389176",
+					"name": "created",
+					"onCreate": true,
+					"onUpdate": false,
+					"presentable": false,
+					"system": false,
+					"type": "autodate"
+				}
+			],
+			"id": "pbc_2332478454",
+			"indexes": [
+				"CREATE UNIQUE INDEX ` + "`" + `idx_dPMa43KaQj` + "`" + ` ON ` + "`" + `apiKeys` + "`" + ` (` + "`" + `apiKey` + "`" + `)"
+			],
+			"listRule": null,
+			"name": "apiKeys",
+			"system": false,
+			"type": "base",
+			"updateRule": null,
+			"viewRule": null
+		}`
+
+		collection := &core.Collection{}
+		if err := json.Unmarshal([]byte(jsonData), &collection); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("pbc_2332478454")
+		if err != nil {
+			return err
+		}
+
+		return app.Delete(collection)
+	})
+}

--- a/routesApi.go
+++ b/routesApi.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/hook"
+)
+
+func RegisterApiRoutes(se *core.ServeEvent) {
+	se.Router.POST("/api/app/change-tokens", changeTokensApi).Bind(validateApiTokenMiddleware()).Bind(setUserAuthMiddleware())
+
+}
+
+func changeTokensApi(e *core.RequestEvent) error {
+
+	return chaneUsersAmount(e)
+}
+
+func validateApiToken(app core.App, token string) (string, error) {
+	record, err := app.FindFirstRecordByData("apiKeys", "apiKey", token)
+	if err != nil {
+		return "", err
+	}
+	return record.Id, nil
+}
+
+func validateApiTokenMiddleware() *hook.Handler[*core.RequestEvent] {
+	return &hook.Handler[*core.RequestEvent]{
+		Id: "validate-api-token",
+		Func: func(e *core.RequestEvent) error {
+			e.App.Logger().Debug("Validating API token for request", "path", e.Request.URL.Path)
+			token := e.Request.Header.Get("api-token")
+			if token == "" {
+				return e.UnauthorizedError("API toke was not provided.", nil)
+			}
+			tokenID, err := validateApiToken(e.App, token)
+			if err != nil {
+				return e.UnauthorizedError(err.Error(), nil)
+			}
+			e.App.Logger().Debug("API token validated", "path", e.Request.URL.Path, "tokenID", tokenID)
+
+			return e.Next()
+		},
+		Priority: 10,
+	}
+}
+
+func setUserAuthMiddleware() *hook.Handler[*core.RequestEvent] {
+	return &hook.Handler[*core.RequestEvent]{
+		Id: "set-auth-user",
+		Func: func(e *core.RequestEvent) error {
+			discordId := e.Request.Header.Get("discord-user-id")
+			userRecord, err := e.App.FindFirstRecordByData("users", "discordId", discordId)
+			if err != nil {
+				return e.UnauthorizedError("User not found", err)
+			}
+			e.Auth = userRecord
+			e.App.Logger().Debug("User set for request", "path", e.Request.URL.Path, "user", userRecord)
+			return e.Next()
+		},
+		Priority: 20,
+	}
+}


### PR DESCRIPTION
An API endpoint has been introduced to allow the addition of tokens from the bot. This includes the creation of a new collection for API keys and the implementation of middleware for token validation and user authentication.

Fixes #40