### PR TITLE
Update README with setup and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/oldbear24/dkp-auction)](https://goreportcard.com/report/github.com/oldbear24/dkp-auction)
 # DKP Auction House
 
-DKP Auction House is a PocketBase application for managing auctions and bids in a DKP (Dragon Kill Points) system.
+DKP Auction House is a PocketBase application for managing auctions and bids in a DKP (Dragon Kill Points) system. The backend is written in Go and the UI lives in the `web/` SvelteKit app.
 
 ## Features
 
@@ -9,8 +9,16 @@ DKP Auction House is a PocketBase application for managing auctions and bids in 
 - Place bids on auctions
 - Automatically finish auctions and determine winners
 - Notify users about auction updates
+- Scheduled maintenance tasks (auctions, user sync, token health checks)
 
-## Installation
+## Requirements
+
+- Go 1.22+ (backend)
+- Node.js 18+ (frontend, optional for UI changes)
+
+## Getting Started
+
+### Backend (PocketBase)
 
 1. Clone the repository:
     ```sh
@@ -27,3 +35,33 @@ DKP Auction House is a PocketBase application for managing auctions and bids in 
     ```sh
     go run . serve
     ```
+
+PocketBase will create its local data directory and serve the API/UI once running. Static assets are served from `pb_public/` when present.
+
+### Frontend (SvelteKit)
+
+The UI lives under `web/` and can be run separately for local development.
+
+```sh
+cd web
+npm install
+npm run dev
+```
+
+Use `npm run build` to generate a production build.
+
+## Migrations
+
+Migrations are handled via the PocketBase migrate plugin. When running with `go run`, collection changes made in the admin dashboard will auto-generate migrations under `migrations/`.
+
+## Project Structure
+
+- `main.go` and `routes*.go`: backend entry point and route registration
+- `migrations/`: PocketBase migrations
+- `web/`: SvelteKit frontend
+
+## Testing
+
+```sh
+go test ./...
+```


### PR DESCRIPTION
### Motivation
- Provide clearer developer guidance for running the backend and frontend, list requirements, and explain migrations and project layout.

### Description
- Expanded `README.md` to add requirements (`Go 1.22+`, `Node.js 18+`), backend startup instructions (`go run . serve`), frontend dev steps (`cd web`, `npm install`, `npm run dev`), migrations note, project structure, and a `go test ./...` testing hint.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968270a6658832e82b077e8baee714a)