### PR TITLE
Harden auction/token-change handlers, add HTTP timeouts for syncs, and add util tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -58,15 +58,14 @@ func TestGetSettingsReturnsStoredRecord(t *testing.T) {
 }
 
 func TestGetSettingsInsertsDefaultRowWhenMissing(t *testing.T) {
-	t.Skip("Will be fixed later, it is not critical right now")
-	/*app := newTestApp(t)
+	app := newTestApp(t)
 
 	settings, err := GetSettings(app.App)
-	if !errors.Is(err, sql.ErrNoRows) {
-		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	if err != nil {
+		t.Fatalf("GetSettings returned error: %v", err)
 	}
-	if settings != nil {
-		t.Fatalf("expected nil settings when none exist, got %#v", settings)
+	if settings == nil {
+		t.Fatalf("expected settings to be created, got nil")
 	}
 
 	var count int
@@ -75,7 +74,7 @@ func TestGetSettingsInsertsDefaultRowWhenMissing(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("expected a single inserted default row, got %d", count)
-	}*/
+	}
 }
 
 func newTestApp(t *testing.T) *pocketbase.PocketBase {

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func TestCheckIfUserIsInRole(t *testing.T) {
+	app := newTestApp(t)
+
+	user := createTestUser(t, app, "role@example.com", []string{"admin", "member"})
+
+	if !checkIfUserIsInRole(user, "admin") {
+		t.Fatalf("expected user to have admin role")
+	}
+	if checkIfUserIsInRole(user, "lootCouncil") {
+		t.Fatalf("expected user to not have lootCouncil role")
+	}
+}
+
+func TestCreateTransactionRecord(t *testing.T) {
+	app := newTestApp(t)
+
+	user := createTestUser(t, app, "player@example.com", []string{"member"})
+	author := createTestUser(t, app, "author@example.com", []string{"admin"})
+
+	if err := createTransactionRecord(app.App, user.Id, 25, "loot transfer", author.Id); err != nil {
+		t.Fatalf("createTransactionRecord returned error: %v", err)
+	}
+
+	record, err := app.FindFirstRecordByData("transactions", "note", "loot transfer")
+	if err != nil {
+		t.Fatalf("failed to find transaction record: %v", err)
+	}
+
+	if got := record.GetString("user"); got != user.Id {
+		t.Fatalf("expected transaction user %q, got %q", user.Id, got)
+	}
+	if got := record.GetString("author"); got != author.Id {
+		t.Fatalf("expected transaction author %q, got %q", author.Id, got)
+	}
+	if got := record.GetInt("amount"); got != 25 {
+		t.Fatalf("expected transaction amount 25, got %d", got)
+	}
+}
+
+func createTestUser(t *testing.T, app *pocketbase.PocketBase, email string, roles []string) *core.Record {
+	t.Helper()
+
+	collection, err := app.FindCollectionByNameOrId("users")
+	if err != nil {
+		t.Fatalf("failed to find users collection: %v", err)
+	}
+
+	record := core.NewRecord(collection)
+	record.SetEmail(email)
+	record.SetPassword("password-123")
+	record.Set("role", roles)
+
+	if err := app.Save(record); err != nil {
+		t.Fatalf("failed to save user record: %v", err)
+	}
+
+	return record
+}


### PR DESCRIPTION
### Motivation
- Prevent invalid state transitions and hidden errors during auction resolution, token updates, and bidding by adding earlier returns and clearer validations.
- Make external sync cron jobs more robust against slow or non-200 responses by adding timeouts and explicit status checks.
- Improve test coverage for core utility helpers to catch regressions in role checks and transaction creation.

### Description
- In `routes.go` return early from `resolveAuction` on already-resolved records, validate `chaneUsersAmount` input (`UserIds` required and `Amount` != 0) before starting a transaction, and remove the redundant in-loop amount check by validating once up front in `chaneUsersAmount`.
- In `routes.go` handle the error from `FindRecordsByFilter` for existing bids immediately in `handleBid` to avoid using a nil/invalid slice and potential panics.
- In `cronJobs.go` add `time` imports and use `http.Client` instances with `Timeout` values, check `resp.StatusCode` for non-OK responses for login and data fetch calls, and consistently close response bodies (including image fetch failure paths).
- Re-enabled and adjusted `TestGetSettingsInsertsDefaultRowWhenMissing` in `main_test.go` to expect a default `settings` row to be created when missing, and added `util_test.go` with `TestCheckIfUserIsInRole`, `TestCreateTransactionRecord`, and a `createTestUser` helper.

### Testing
- Ran formatting with `gofmt -w routes.go cronJobs.go` which completed successfully.
- No automated test suite was executed in this environment, although new tests were added in `util_test.go` and `TestGetSettingsInsertsDefaultRowWhenMissing` was re-enabled in `main_test.go` (tests not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a3916cf8832e957767c4ed6f5c3a)