### PR TITLE
Add build-time version metadata for backend and web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
 #build stage
 FROM golang:alpine AS builder-go
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
 RUN apk add --no-cache git
 WORKDIR /go/src/app
 COPY . .
 RUN go get -d -v ./...
-RUN go build -o /go/bin/app -v .
+RUN go build -ldflags "-X main.buildVersion=${VERSION} -X main.buildCommit=${COMMIT} -X main.buildDate=${BUILD_DATE}" -o /go/bin/app -v .
 
 #web build stage
 FROM node:lts-alpine AS builder-web
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+ENV VITE_APP_VERSION=${VERSION}
+ENV VITE_APP_COMMIT=${COMMIT}
+ENV VITE_APP_BUILD_DATE=${BUILD_DATE}
 WORKDIR /usr/src/app
 COPY ./web .
 RUN npm ci
@@ -15,10 +24,11 @@ RUN npm run build
 
 #final stage
 FROM alpine:latest
+ARG VERSION=dev
 RUN apk --no-cache add ca-certificates
 COPY --from=builder-go /go/bin/app /app
 COPY --from=builder-web /usr/src/app/build /pb_public
 
 CMD ["/app", "serve", "--http=0.0.0.0:3000"]
-LABEL Name=dkpauction Version=0.0.1
+LABEL Name=dkpauction Version=${VERSION}
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -65,3 +65,19 @@ Migrations are handled via the PocketBase migrate plugin. When running with `go 
 ```sh
 go test ./...
 ```
+
+## Build versioning
+
+The backend and web UI can embed version metadata at build time. The Go binary reads
+`VERSION`, `COMMIT`, and `BUILD_DATE` via linker flags, and the Svelte app reads the same
+values via `VITE_APP_*` env vars in the Docker build.
+
+Example Docker build:
+
+```sh
+docker build \
+  --build-arg VERSION=$(git describe --tags --always) \
+  --build-arg COMMIT=$(git rev-parse --short HEAD) \
+  --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -t dkp-auction:$(git describe --tags --always) .
+```

--- a/routesApi.go
+++ b/routesApi.go
@@ -8,7 +8,12 @@ import (
 // RegisterApiRoutes wires API endpoints and middleware for server-side token operations.
 func RegisterApiRoutes(se *core.ServeEvent) {
 	se.Router.POST("/api/app/change-tokens", changeTokensApi).Bind(validateApiTokenMiddleware()).Bind(setUserAuthMiddleware())
+	se.Router.GET("/api/version", appVersion)
 
+}
+
+func appVersion(e *core.RequestEvent) error {
+	return e.JSON(200, versionInfo())
 }
 
 // changeTokensApi handles token change requests using the shared change handler.

--- a/version.go
+++ b/version.go
@@ -1,0 +1,18 @@
+package main
+
+// buildVersion is set at build time via -ldflags "-X main.buildVersion=...".
+var buildVersion = "dev"
+
+// buildCommit is set at build time via -ldflags "-X main.buildCommit=...".
+var buildCommit = "unknown"
+
+// buildDate is set at build time via -ldflags "-X main.buildDate=...".
+var buildDate = "unknown"
+
+func versionInfo() map[string]string {
+	return map[string]string{
+		"version": buildVersion,
+		"commit":  buildCommit,
+		"date":    buildDate,
+	}
+}

--- a/web/src/components/NavBar.svelte
+++ b/web/src/components/NavBar.svelte
@@ -5,6 +5,7 @@
 	import ToastManager from './ToastManager.svelte';
 	import { writable } from 'svelte/store';
 	import NotificationsList from './NotificationsList.svelte';
+	import { appVersion } from '$lib/version';
 	let notificationListComponent: NotificationsList;
 	let notificationCount = writable(0);
   const openNotification = writable(false);
@@ -57,7 +58,8 @@
 		<a class="btn btn-ghost text-xl" href="/">Auction House</a>
 	</div>
 
-	<div class="flex-none pr-3">
+	<div class="flex-none pr-3 flex items-center gap-2">
+		<span class="text-xs opacity-70">v{appVersion.version}</span>
 		{#if $user}
 			<div
 				data-tip="Your current tokens and usable tokens."

--- a/web/src/lib/version.ts
+++ b/web/src/lib/version.ts
@@ -1,0 +1,5 @@
+export const appVersion = {
+	version: import.meta.env.VITE_APP_VERSION ?? 'dev',
+	commit: import.meta.env.VITE_APP_COMMIT ?? 'unknown',
+	date: import.meta.env.VITE_APP_BUILD_DATE ?? 'unknown'
+};


### PR DESCRIPTION
### Motivation

- Provide reproducible build/version information for both the Go backend and the Svelte web UI and make it available at runtime.

### Description

- Add `version.go` to store `buildVersion`, `buildCommit`, and `buildDate` and expose them via a new `/api/version` endpoint in `routesApi.go` using `versionInfo()`.
- Wire Docker build arguments into the Go linker flags and Vite env variables by updating `Dockerfile` to accept `VERSION`, `COMMIT`, and `BUILD_DATE` and pass them to the Go `-ldflags` and `VITE_APP_*` envs for the web build.
- Add a small web helper `web/src/lib/version.ts` and display the app version in the navbar `web/src/components/NavBar.svelte`.
- Document the build-time versioning flow and provide an example `docker build` command in `README.md`.

### Testing

- Ran `gofmt -w version.go` to format the new file, which completed successfully.
- Installed web dependencies with `npm install` inside `web/`, which completed successfully.
- Started the dev web server with `npm run dev` (Vite started and served locally), which completed successfully.
- Ran a headless Playwright script to load the dev site and capture a screenshot of the navbar (artifact produced), which completed successfully.
- No Go unit tests (`go test`) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5181a45c832e8b5798256ad885fc)