### PR TITLE
Pass Docker build args in workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,6 +101,22 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set build args
+        id: build-args
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="dev-${GITHUB_SHA::7}"
+          fi
+          build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "version=${version}"
+            echo "commit=${GITHUB_SHA}"
+            echo "build_date=${build_date}"
+          } >> "$GITHUB_OUTPUT"
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -111,6 +127,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.build-args.outputs.version }}
+            COMMIT=${{ steps.build-args.outputs.commit }}
+            BUILD_DATE=${{ steps.build-args.outputs.build_date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
### Motivation

- The Docker workflow did not supply build-time metadata, so image builds lacked embedded `VERSION`, `COMMIT`, and `BUILD_DATE` information.
- Ensure CI-determined version information (tags or commit SHA) and build timestamp are propagated into the Docker build for binary and web assets.

### Description

- Add a `Set build args` step in `.github/workflows/docker-publish.yml` that computes `version`, `commit`, and `build_date` and emits them to `GITHUB_OUTPUT`.
- Derive `version` from `GITHUB_REF_TYPE`/`GITHUB_REF_NAME` (use tag when present, otherwise `dev-<short-sha>`), and format `build_date` as UTC ISO8601.
- Pass the generated values into `docker/build-push-action` via `build-args` as `VERSION`, `COMMIT`, and `BUILD_DATE` so the Dockerfile `ARG` values (and downstream `ldflags`/web env) receive CI metadata.

### Testing

- No automated tests were executed for this change because it only modifies the GitHub Actions workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a577dab74832e9cd7b1348d1dc9a7)