### PR TITLE
Add separate page for auction

### DIFF
--- a/web/src/routes/auction/+page.svelte
+++ b/web/src/routes/auction/+page.svelte
@@ -26,7 +26,7 @@
     }
   });
 
-onDestroy(() => {
+  onDestroy(() => {
     if (id) {
       pb.collection('auctions').unsubscribe(id);
     }


### PR DESCRIPTION
Introduce a dedicated page for displaying auction details. This feature allows users to view specific auction items, handle loading states, and manage real-time updates for auction data.

Fixes #87